### PR TITLE
Fix Uncaught ReferenceError: startPosition is not defined

### DIFF
--- a/src/revealer.js
+++ b/src/revealer.js
@@ -112,7 +112,7 @@
           angular.element($window).on('scroll', handleScroll);
         }
 
-        (!scope.scroll) ? setRevealPosition(handle, topImage, startPosition) : setRevealPosition(handle, topImage, 0);
+        (!scope.scroll) ? setRevealPosition(handle, topImage, scope.startPosition) : setRevealPosition(handle, topImage, 0);
 
         angular.forEach(multipleEvents, function(eventConfig) {
 


### PR DESCRIPTION
Hello. I found small issue in revealer, when I used it with start-position attribute.
`revealer.js:115 Uncaught ReferenceError: startPosition is not defined`
